### PR TITLE
Consistently use single quotes for arguments

### DIFF
--- a/proxysql-admin.cnf
+++ b/proxysql-admin.cnf
@@ -4,14 +4,14 @@ export PROXYSQL_DATADIR='/var/lib/proxysql'
 # --------------------------------
 # encrypted login credentials file options
 #
-#export LOGIN_FILE="/path/to/loginfile"
-#export LOGIN_PASSWORD_FILE="/path/to/loginfile/password"
+#export LOGIN_FILE='/path/to/loginfile'
+#export LOGIN_PASSWORD_FILE='/path/to/loginfile/password'
 
 # --------------------------------
 # proxysql admin interface credentials.
 #
-export PROXYSQL_USERNAME="admin"
-export PROXYSQL_PASSWORD="admin"
+export PROXYSQL_USERNAME='admin'
+export PROXYSQL_PASSWORD='admin'
 export PROXYSQL_HOSTNAME='localhost'
 export PROXYSQL_PORT='6032'
 
@@ -47,12 +47,12 @@ export OFFLINE_HOSTGROUP_ID='13'
 # --------------------------------
 # ProxySQL read/write configuration mode.
 #
-export MODE="singlewrite"
+export MODE='singlewrite'
 
 # --------------------------------
 # max_connections default (used only when INSERTing a new mysql_servers entry)
 #
-export MAX_CONNECTIONS="1000"
+export MAX_CONNECTIONS='1000'
 
 # --------------------------------
 # Determines the maximum number of writesets a node can have queued
@@ -63,7 +63,7 @@ export MAX_TRANSACTIONS_BEHIND=100
 # --------------------------------
 # Connections to the backend servers (from ProxySQL) will use SSL
 #
-export USE_SSL="no"
+export USE_SSL='no'
 
 # --------------------------------
 # Determines if a node should be added to the reader hostgroup if it has
@@ -74,4 +74,4 @@ export USE_SSL="no"
 # If set to 'backup', then only the backup-writers will be added to
 # the read hostgroup.
 #
-export WRITERS_ARE_READERS="backup"
+export WRITERS_ARE_READERS='backup'


### PR DESCRIPTION
no more double quotes in the configuration file